### PR TITLE
Support unprivileged containers like those ran by toolbx

### DIFF
--- a/source/moss/container/package.d
+++ b/source/moss/container/package.d
@@ -42,9 +42,8 @@ public final class Container
             Mount("proc", context.joinPath("/proc"), "proc",
                     MountFlags.NoSuid | MountFlags.NoDev | MountFlags.NoExec
                     | MountFlags.RelativeAccessTime),
-            Mount("sysfs", context.joinPath("/sys"), "sysfs",
-                    MountFlags.NoSuid | MountFlags.NoDev | MountFlags.NoExec
-                    | MountFlags.RelativeAccessTime),
+            Mount("/sys", context.joinPath("/sys"), "",
+                    MountFlags.Bind | MountFlags.Rec),
             Mount("tmpfs", context.joinPath("/tmp"), "tmpfs",
                     MountFlags.NoSuid | MountFlags.NoDev),
 

--- a/source/moss/container/package.d
+++ b/source/moss/container/package.d
@@ -21,7 +21,7 @@ public import moss.container.process;
 import moss.container.context;
 import std.exception : enforce;
 import std.experimental.logger;
-import std.file : exists, remove, symlink, mkdirRecurse, copy;
+import std.file : copy, exists, mkdirRecurse, remove, symlink, write;
 import std.process;
 import std.path : dirName;
 import std.stdio : stderr, stdin, stdout;
@@ -39,20 +39,23 @@ public final class Container
     {
         /* Default mount points */
         mountPoints = [
-            Mount("proc", context.joinPath("/proc"), "proc",
+            Mount("", context.joinPath("/proc"), "proc",
                     MountFlags.NoSuid | MountFlags.NoDev | MountFlags.NoExec
                     | MountFlags.RelativeAccessTime),
             Mount("/sys", context.joinPath("/sys"), "",
                     MountFlags.Bind | MountFlags.Rec),
-            Mount("tmpfs", context.joinPath("/tmp"), "tmpfs",
-                    MountFlags.NoSuid | MountFlags.NoDev),
+            Mount("", context.joinPath("/tmp"), "tmpfs",
+                    MountFlags.NoSuid | MountFlags.NoDev)
+        ];
 
-            /* /dev points */
-            Mount("tmpfs", context.joinPath("/dev"), "tmpfs",
-                    MountFlags.NoSuid | MountFlags.NoExec),
-            Mount("tmpfs", context.joinPath("/dev/shm"), "tmpfs",
+        /* /dev points */
+        auto dev = Mount("", context.joinPath("/dev"), "tmpfs", MountFlags.NoSuid | MountFlags.NoExec);
+        dev.setData("mode=777".toStringz());
+        mountPoints ~= [
+            dev,
+            Mount("", context.joinPath("/dev/shm"), "tmpfs",
                     MountFlags.NoSuid | MountFlags.NoDev),
-            Mount("devpts", context.joinPath("/dev/pts"), "devpts",
+            Mount("", context.joinPath("/dev/pts"), "devpts",
                     MountFlags.NoSuid | MountFlags.NoExec | MountFlags.RelativeAccessTime),
         ];
     }
@@ -149,7 +152,6 @@ private:
      */
     void configureDevfs()
     {
-
         auto symlinkSources = [
             "/proc/self/fd", "/proc/self/fd/0", "/proc/self/fd/1",
             "/proc/self/fd/2", "pts/ptmx"
@@ -159,13 +161,17 @@ private:
             "/dev/fd", "/dev/stdin", "/dev/stdout", "/dev/stderr", "/dev/ptmx"
         ];
 
-        static DeviceNode[] nodes = [
-            DeviceNode("/dev/null", S_IFCHR | octal!666, mkdev(1, 3)),
-            DeviceNode("/dev/zero", S_IFCHR | octal!666, mkdev(1, 5)),
-            DeviceNode("/dev/full", S_IFCHR | octal!666, mkdev(1, 7)),
-            DeviceNode("/dev/random", S_IFCHR | octal!666, mkdev(1, 8)),
-            DeviceNode("/dev/urandom", S_IFCHR | octal!666, mkdev(1, 9)),
-            DeviceNode("/dev/tty", S_IFCHR | octal!666, mkdev(5, 0)),
+        /* Can't use mknod because we want to support unprivileged containers
+         * like Podman or Docker. Let's bind mount existing nodes to circumvent
+         * this limitation.
+         */
+        Mount[] nodes = [
+            Mount("/dev/null", context.joinPath("/dev/null"), "", MountFlags.Bind),
+            Mount("/dev/zero", context.joinPath("/dev/zero"), "", MountFlags.Bind),
+            Mount("/dev/full", context.joinPath("/dev/full"), "", MountFlags.Bind),
+            Mount("/dev/random", context.joinPath("/dev/random"), "", MountFlags.Bind),
+            Mount("/dev/urandom", context.joinPath("/dev/urandom"), "", MountFlags.Bind),
+            Mount("/dev/tty", context.joinPath("/dev/tty"), "", MountFlags.Bind),
         ];
 
         /* Link sources to targets */
@@ -187,7 +193,8 @@ private:
         /* Create our nodes */
         foreach (ref n; nodes)
         {
-            n.create();
+            write(n.target, null); /* Create the empty file first. */
+            n.mount();
         }
     }
 

--- a/source/moss/container/package.d
+++ b/source/moss/container/package.d
@@ -135,7 +135,7 @@ private:
     {
         foreach_reverse (ref m; mountPoints)
         {
-            m.unmountFlags = UnmountFlags.Force | UnmountFlags.Detach;
+            m.unmountFlags = UnmountFlags.Detach;
             auto err = m.unmount();
             if (!err.isNull())
             {

--- a/source/moss/container/package.d
+++ b/source/moss/container/package.d
@@ -43,7 +43,7 @@ public final class Container
                     MountFlags.NoSuid | MountFlags.NoDev | MountFlags.NoExec
                     | MountFlags.RelativeAccessTime),
             Mount("/sys", context.joinPath("/sys"), "",
-                    MountFlags.Bind | MountFlags.Rec),
+                    MountFlags.Bind | MountFlags.Rec | MountFlags.ReadOnly),
             Mount("", context.joinPath("/tmp"), "tmpfs",
                     MountFlags.NoSuid | MountFlags.NoDev)
         ];


### PR DESCRIPTION
Depends on https://github.com/serpent-os/moss-core/pull/10

Note that this PR is identical to https://github.com/serpent-os/moss-container/pull/3, it just uses a differently spelled source branch.