### PR TITLE
moss-container: Allow user to choose cwd to start at.

### DIFF
--- a/source/main.d
+++ b/source/main.d
@@ -61,6 +61,10 @@ public struct ContainerCLI
     @Option("d", "directory", "Directory to find a root filesystem")
     string rootfsDir = null;
 
+    /** Immediately start at this directory in the container (cwd) */
+    @Option("workdir", null, "Start at this working directory in the container (Default: /)")
+    string cwd = "/";
+
     /** Toggle fakeroot use */
     @Option("f", "fakeroot", "Enable fakeroot integration")
     bool fakeroot = false;
@@ -134,7 +138,7 @@ public struct ContainerCLI
         /* Setup rootfs - ensure we're running as root too */
         context.rootfs = rootfsDir;
         context.fakeroot = fakeroot;
-        context.workDir = "/";
+        context.workDir = cwd;
         context.environment = environment;
         context.effectiveUID = uid;
         context.networking = networking;

--- a/source/moss/container/context.d
+++ b/source/moss/container/context.d
@@ -99,22 +99,6 @@ public final class Context
     }
 
     /**
-     * Return the working directory used for the process
-     */
-    pure @property const(string) workDir() @safe @nogc nothrow const
-    {
-        return cast(const(string)) workDir;
-    }
-
-    /**
-     * Set the working directory in which to execute the process
-     */
-    pure @property void workDir(in string newDir) @safe @nogc nothrow
-    {
-        _workDir = newDir;
-    }
-
-    /**
      * Safely join the path onto the rootfs tree
      */
     auto joinPath(in string target) @safe
@@ -158,6 +142,11 @@ public final class Context
      */
     string[string] environment;
 
+    /**
+     * Current working directory
+     */
+    string workDir;
+
 package:
 
     /**
@@ -189,7 +178,6 @@ private:
     string _rootfs = null;
     FakerootBinary _fakerootBinary = FakerootBinary.None;
     bool _fakeroot = false;
-    string _workDir = ".";
     uid_t _effectiveUID;
     bool _networking;
 }

--- a/source/moss/container/process.d
+++ b/source/moss/container/process.d
@@ -113,7 +113,7 @@ private:
         try
         {
             auto pid = spawnProcess(finalArgs, stdin, stdout, stderr,
-                    context.environment, config, "/");
+                    context.environment, config, context.workDir);
             return wait(pid);
         }
         catch (ProcessException px)


### PR DESCRIPTION
Allows the user to immediately chroot at a specified directory instead of "/".